### PR TITLE
✨ Feat: talkieByCategoryAPI

### DIFF
--- a/apis/controllers/talkieController.js
+++ b/apis/controllers/talkieController.js
@@ -75,9 +75,18 @@ const deleteBookmark = catchAsync(async (req, res) => {
 	res.status(204).json({ message: "DELETION_COMPLETED_SUCCESSFULLY" });
 });
 
+const getTalkieCardByEncounter = catchAsync((req, res) => {
+	const { encounter_id } = req.params;
+	const { isUser, user } = req.headers;
+});
+
+const getTalkieCardByTopic = catchAsync((req, res) => {});
+
 module.exports = {
 	getTalkieCard,
 	getBookmarkedTalkies,
 	bookmarkTalkie,
 	deleteBookmark,
+	getTalkieCardByEncounter,
+	getTalkieCardByTopic,
 };

--- a/apis/controllers/talkieController.js
+++ b/apis/controllers/talkieController.js
@@ -76,14 +76,16 @@ const deleteBookmark = catchAsync(async (req, res) => {
 });
 
 const getTalkieCardByEncounter = catchAsync(async (req, res) => {
-	const { encounter_id } = req.params;
 	const { isUser } = req.headers;
 	const { id: user_id } = req.user;
+	const { encounter_id } = req.params;
+	const { start } = req.query;
 
 	const data = await talkieService.getTalkieCardByEncounter(
 		isUser,
-		user_id,
-		encounter_id
+		encounter_id,
+		start,
+		user_id
 	);
 
 	res.status(200).json({ data });
@@ -96,11 +98,13 @@ const getTalkieCardByTopic = catchAsync(async (req, res) => {
 	const { isUser } = req.headers;
 	const { id: user_id } = req.user;
 	const { topic_id } = req.params;
+	const { start } = req.query;
 
 	const data = await talkieService.getTalkieCardByTopic(
 		isUser,
-		user_id,
-		topic_id
+		topic_id,
+		start,
+		user_id
 	);
 
 	res.status(200).json({ data });

--- a/apis/controllers/talkieController.js
+++ b/apis/controllers/talkieController.js
@@ -75,12 +75,36 @@ const deleteBookmark = catchAsync(async (req, res) => {
 	res.status(204).json({ message: "DELETION_COMPLETED_SUCCESSFULLY" });
 });
 
-const getTalkieCardByEncounter = catchAsync((req, res) => {
+const getTalkieCardByEncounter = catchAsync(async (req, res) => {
 	const { encounter_id } = req.params;
-	const { isUser, user } = req.headers;
+	const { isUser } = req.headers;
+	const { id: user_id } = req.user;
+
+	const data = await talkieService.getTalkieCardByEncounter(
+		isUser,
+		user_id,
+		encounter_id
+	);
+
+	res.status(200).json({ data });
 });
 
-const getTalkieCardByTopic = catchAsync((req, res) => {});
+const getTalkieCardByTopic = catchAsync(async (req, res) => {
+	// topic_id 를 받으면 토픽에 해당하는 talkie 리스트 반환하는 API
+	// topic 추천 5개도 보내야하는데... Left join을 쓰는 게 나을 까 각각 DB 연결을 따로 하는 게 좋을까?
+
+	const { isUser } = req.headers;
+	const { id: user_id } = req.user;
+	const { topic_id } = req.params;
+
+	const data = await talkieService.getTalkieCardByTopic(
+		isUser,
+		user_id,
+		topic_id
+	);
+
+	res.status(200).json({ data });
+});
 
 module.exports = {
 	getTalkieCard,

--- a/apis/models/categoryDao.js
+++ b/apis/models/categoryDao.js
@@ -110,7 +110,19 @@ const getTopicCategory = (mode, user_id) => {
       LEFT JOIN user_interest 
         ON user_id = ${user_id} AND user_interest.topic_id = topic_category.id
       ORDER BY InterestCheck DESC, topic ASC
-  `,
+      `,
+		RECOMMEND: `
+      SELECT
+        topic_category.id AS topic_id,
+        topic,
+        emoji,
+        COUNT(user_interest.id) AS interestedCnt
+      FROM topic_category
+      LEFT JOIN user_interest ON user_interest.topic_id = topic_category.id
+      GROUP BY topic_category.id
+      ORDER BY interestedCnt DESC, topic ASC
+      LIMIT 5 OFFSET ${Math.floor(Math.random() * 20)}
+    `,
 	};
 
 	return talkieDataSource.query(QueryDiversityByMode[mode]);

--- a/apis/models/talkieDao.js
+++ b/apis/models/talkieDao.js
@@ -85,6 +85,28 @@ const deleteBookmark = (bookmark_id) => {
   `);
 };
 
+const getTalkieCardByEncounter = (mode, user, encounter_id) => {
+	const QuryByMode = {
+		GUEST: `
+    SELECT
+      id,
+      talk,
+      emoji
+    FROM small_talks
+    LEFT JOIN encounter_talk ON small_talks.id = encounter_id = ${encounter_id}
+  `,
+		USER: ``,
+	};
+
+	return talkieDataSource.query(QuryByMode[mode]);
+};
+
+const getTalkieCardByTopic = () => {
+	return talkieDataSource.query(`
+  
+  `);
+};
+
 module.exports = {
 	getTalkieCard,
 	getBookmarkedTalkies,
@@ -92,4 +114,6 @@ module.exports = {
 	checkBookmarkByUserAndTalkie,
 	bookmarkTalkie,
 	deleteBookmark,
+	getTalkieCardByEncounter,
+	getTalkieCardByTopic,
 };

--- a/apis/routes/categoryRouter.js
+++ b/apis/routes/categoryRouter.js
@@ -16,6 +16,6 @@ router.get(
 	categoryController.getEncounterCategoryListBySituation
 );
 
-router.get("/topic", AuthMiddleware, categoryController);
+router.get("/topic", AuthMiddleware, categoryController.getTopicCategory);
 
 module.exports = router;

--- a/apis/routes/talkieRouter.js
+++ b/apis/routes/talkieRouter.js
@@ -20,4 +20,16 @@ router.delete(
 	talkieController.deleteBookmark
 );
 
+router.get(
+	"/encounter/:encounter_id",
+	AuthMiddleware,
+	talkieController.getTalkieCardByEncounter
+);
+
+router.get(
+	"/topic/:topic_id",
+	AuthMiddleware,
+	talkieController.getTalkieCardByTopic
+);
+
 module.exports = router;

--- a/apis/services/talkieService.js
+++ b/apis/services/talkieService.js
@@ -55,20 +55,22 @@ const deleteBookmark = async (bookmark_id, user_id) => {
 	return talkieDao.deleteBookmark(bookmark_id);
 };
 
-const getTalkieCardByEncounter = async (mode, user_id, encounter_id) => {
+const getTalkieCardByEncounter = async (mode, encounter_id, start, user_id) => {
 	const data = await talkieDao.getTalkieCardByEncounter(
 		mode,
-		user_id,
-		encounter_id
+		encounter_id,
+		start,
+		user_id
 	);
 
 	return data;
 };
 
-const getTalkieCardByTopic = async (mode, user_id, topic_id) => {
-	const talkie = talkieDao.getTalkieCardByTopic(mode, user_id, topic_id);
+const getTalkieCardByTopic = async (mode, topic_id, start, user_id) => {
+	const topics = await categoryDao.getTopicCategory("RECOMMEND");
+	const talkie = talkieDao.getTalkieCardByTopic(mode, topic_id, start, user_id);
 
-	const topics = await categoryDao.getTopicCategory();
+	return { topics, talkie };
 };
 
 module.exports = {

--- a/apis/services/talkieService.js
+++ b/apis/services/talkieService.js
@@ -1,4 +1,5 @@
 const talkieDao = require("../models/talkieDao");
+const categoryDao = require("../models/categoryDao");
 
 const getTalkieCard = (isUser, user_id, offset) => {
 	const StrategyByMode = {
@@ -54,12 +55,20 @@ const deleteBookmark = async (bookmark_id, user_id) => {
 	return talkieDao.deleteBookmark(bookmark_id);
 };
 
-const getTalkieCardByEncounter = async (mode, user, encounter_id) => {
+const getTalkieCardByEncounter = async (mode, user_id, encounter_id) => {
 	const data = await talkieDao.getTalkieCardByEncounter(
 		mode,
-		user,
+		user_id,
 		encounter_id
 	);
+
+	return data;
+};
+
+const getTalkieCardByTopic = async (mode, user_id, topic_id) => {
+	const talkie = talkieDao.getTalkieCardByTopic(mode, user_id, topic_id);
+
+	const topics = await categoryDao.getTopicCategory();
 };
 
 module.exports = {
@@ -68,4 +77,5 @@ module.exports = {
 	bookmarkTalkie,
 	deleteBookmark,
 	getTalkieCardByEncounter,
+	getTalkieCardByTopic,
 };

--- a/apis/services/talkieService.js
+++ b/apis/services/talkieService.js
@@ -54,9 +54,18 @@ const deleteBookmark = async (bookmark_id, user_id) => {
 	return talkieDao.deleteBookmark(bookmark_id);
 };
 
+const getTalkieCardByEncounter = async (mode, user, encounter_id) => {
+	const data = await talkieDao.getTalkieCardByEncounter(
+		mode,
+		user,
+		encounter_id
+	);
+};
+
 module.exports = {
 	getTalkieCard,
 	getBookmarkedTalkies,
 	bookmarkTalkie,
 	deleteBookmark,
+	getTalkieCardByEncounter,
 };

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -19,7 +19,10 @@ CREATE TABLE `encounter_category` (
   `id` int NOT NULL AUTO_INCREMENT,
   `encounter` varchar(50) NOT NULL,
   `emoji` varchar(60) DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  `situation_id` int NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `situation_id` (`situation_id`),
+  CONSTRAINT `encounter_category_ibfk_1` FOREIGN KEY (`situation_id`) REFERENCES `situation_category` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -179,5 +182,6 @@ INSERT INTO `schema_migrations` (version) VALUES
   ('20230612082751'),
   ('20230612082754'),
   ('20230612082810'),
-  ('20230612082824');
+  ('20230612082824'),
+  ('20230704110752');
 UNLOCK TABLES;


### PR DESCRIPTION
# PR template

## ☘️ 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

---


## 🔑 Key Changes

- Encounter Category 별 talkie 리스트 정보 반환

- Topic 카테고리 별 talkie 리스트 정보 반환
  - 해당 토픽 이외 추천 토픽 카테고리 5개의 정보 함께 반환, 선택 가능하도록 함.
  - 기획 상 관심 토픽 리스트를 내보내려 했으나, 항상 똑같은 정보를 노출하는 것보다 다른 카테고리를 노출시키는 것이 유저가 이용하는데 있어 다양성이 생길 것 같음.

- 공통 사항
  - 모드별 실행 : 헤더에 함께 담긴 "isUser"라는 키값으로 DB 커넥션 시 실행되는 쿼리 모듈화
  - 모드(게스트/유저)별 필요한 request 정보와 반환하는 response 정보가 상이



---

## 😎 To Reviewers

- 