### PR TITLE
:sparkles: Feat : getMyPageInfoAPI

### DIFF
--- a/apis/controllers/userController.js
+++ b/apis/controllers/userController.js
@@ -32,9 +32,9 @@ const signin = catchAsync(async (req, res) => {
 		throw error;
 	}
 
-	const authorization = await userService.signin(access_token);
+	const { authorization, darkmode } = await userService.signin(access_token);
 
-	res.status(200).json({ message: "LOGIN_SUCCESS", authorization });
+	res.status(200).json({ message: "LOGIN_SUCCESS", authorization, darkmode });
 });
 
 const getUserInfo = catchAsync((req, res) => {
@@ -45,4 +45,14 @@ const getUserInfo = catchAsync((req, res) => {
 	res.status(200).json({ message: "", data });
 });
 
-module.exports = { signup, signin, getUserInfo };
+const modifyDarkmode = catchAsync((req, res) => {
+	const { user_id } = req.user;
+
+	const result = userService.modifyDarkmode(user_id);
+
+	res
+		.status(200)
+		.message({ message: `MODE_HAS_BEEN_CHANED_TO_${result}_MODE` });
+});
+
+module.exports = { signup, signin, getUserInfo, modifyDarkmode };

--- a/apis/controllers/userController.js
+++ b/apis/controllers/userController.js
@@ -37,4 +37,12 @@ const signin = catchAsync(async (req, res) => {
 	res.status(200).json({ message: "LOGIN_SUCCESS", authorization });
 });
 
-module.exports = { signup, signin };
+const getUserInfo = catchAsync((req, res) => {
+	const { user_id } = req.user;
+
+	const data = userService.getUserInfo(user_id);
+
+	res.status(200).json({ message: "", data });
+});
+
+module.exports = { signup, signin, getUserInfo };

--- a/apis/models/userDao.js
+++ b/apis/models/userDao.js
@@ -12,7 +12,7 @@ const { talkieDataSource } = require("./talkieDataSource");
 const checkDuplicated = (kakao_client_id) => {
 	return talkieDataSource.query(`
     SELECT
-      id
+      user_id
     FROM users
     WHERE kakao_client = ${kakao_client_id}
   `).length
@@ -25,7 +25,8 @@ const getUserInfo = (mode, id) => {
 		KAKAO_ID: `
       SELECT
         user_id,
-        nickname
+        nickname,
+        darkmode
       FROM users
       WHERE kakao_client = ${id}
       `,
@@ -70,4 +71,17 @@ const addUserInterest = (interestQuery) => {
   `);
 };
 
-module.exports = { checkDuplicated, getUserInfo, signup, addUserInterest };
+const modifyDarkmode = (user_id, modeToChange) => {
+	return talkieDataSource.query(`
+    UPDATE darkmode SET darkmode = ${modeToChange}
+    WHERE user_id = ${user_id}
+  `);
+};
+
+module.exports = {
+	checkDuplicated,
+	getUserInfo,
+	signup,
+	addUserInterest,
+	modifyDarkmode,
+};

--- a/apis/models/userDao.js
+++ b/apis/models/userDao.js
@@ -20,14 +20,27 @@ const checkDuplicated = (kakao_client_id) => {
 		: false;
 };
 
-const getUserInfo = (kakao_client_id) => {
-	return talkieDataSource.query(`
-    SELECT
-      id,
-      nickname
-    FROM users
-    WHERE kakao_client = ${kakao_client_id}
-  `);
+const getUserInfo = (mode, id) => {
+	const queryByMode = {
+		KAKAO_ID: `
+      SELECT
+        user_id,
+        nickname
+      FROM users
+      WHERE kakao_client = ${id}
+      `,
+		APP_ID: `
+      SELECT
+        nickname,
+        email,
+        darkmode,
+        profile_image_url
+      FROM users
+      WHERE user_id = ${id}
+    `,
+	};
+
+	return talkieDataSource.query(queryByMode[mode]);
 }; //nickname
 
 // 여기까지

--- a/apis/routes/userRouter.js
+++ b/apis/routes/userRouter.js
@@ -6,6 +6,7 @@ const AuthMiddleware = require("../utils/authMiddleware");
 
 router.post("/signup", userController.signup);
 router.post("/signin", userController.signin);
+router.patch("", AuthMiddleware, userController.modifyDarkmode);
 router.get("", AuthMiddleware, userController.getUserInfo);
 
 module.exports = router;

--- a/apis/routes/userRouter.js
+++ b/apis/routes/userRouter.js
@@ -2,8 +2,10 @@ const express = require("express");
 const router = express.Router();
 
 const userController = require("../controllers/userController");
+const AuthMiddleware = require("../utils/authMiddleware");
 
 router.post("/signup", userController.signup);
 router.post("/signin", userController.signin);
+router.get("", AuthMiddleware, userController.getUserInfo);
 
 module.exports = router;

--- a/apis/services/userService.js
+++ b/apis/services/userService.js
@@ -62,7 +62,13 @@ const signin = async (access_token) => {
 		error.statusCode = 401;
 		throw error;
 	}
-	return jwt.sign(AccountInfo, process.env.JWT_SECRET_KEY);
+
+	const access_token = jwt.sign(AccountInfo, process.env.JWT_SECRET_KEY);
+
+	return {
+		authorization,
+		darkmode: AccountInfo.darkmode,
+	};
 	// 회원 정보 수정에 관한 결정 여부
 };
 
@@ -71,7 +77,25 @@ const getUserInfo = async (user_id) => {
 	return data;
 };
 
-module.exports = { signup, signin, getUserInfo };
+const modifyDarkmode = async (user_id) => {
+	const [current] = await userDao.getUserInfo("APP_ID", user_id);
+
+	const modeToChange = { 1: 0, 0: 1 };
+	// MODEL에 유저 데이터 정보 변경 요청할 때 쓰이는 데이터
+	// 1이 다크모드, 0이 라이트 모드
+
+	const MODE_ENUM = Object.freeze({
+		1: "DARK",
+		0: "LIGHT",
+	});
+	// CONTROLLER로 어떤 모드로 전환되었는 지에 관한 정보를 주기 위한 데이터
+
+	await userDao.modifyDarkmode(user_id, modeToChange[current]);
+
+	return MODE_ENUM[modeToChange[current]];
+};
+
+module.exports = { signup, signin, getUserInfo, modifyDarkmode };
 
 const getUserInfoFromKakao = async (access_token) => {
 	const result = await axios.post("https://kapi.kakao.com/v2/user/me", {

--- a/apis/services/userService.js
+++ b/apis/services/userService.js
@@ -55,7 +55,7 @@ const signup = async (access_token, interest) => {
 const signin = async (access_token) => {
 	const { kakao_client_id } = await getUserInfoFromKakao(access_token);
 
-	const [AccountInfo] = await userDao.getUserInfo(kakao_client_id);
+	const [AccountInfo] = await userDao.getUserInfo("KAKAO_ID", kakao_client_id);
 
 	if (!AccountInfo) {
 		const error = new Error("SIGNUP_REQUIRED");
@@ -66,7 +66,12 @@ const signin = async (access_token) => {
 	// 회원 정보 수정에 관한 결정 여부
 };
 
-module.exports = { signup, signin };
+const getUserInfo = async (user_id) => {
+	const data = await userDao.getUserInfo("APP_ID", user_id);
+	return data;
+};
+
+module.exports = { signup, signin, getUserInfo };
 
 const getUserInfoFromKakao = async (access_token) => {
 	const result = await axios.post("https://kapi.kakao.com/v2/user/me", {

--- a/db/migrations/20230714065552_alter_user_tbl_add_darkmode.sql
+++ b/db/migrations/20230714065552_alter_user_tbl_add_darkmode.sql
@@ -3,4 +3,5 @@ ALTER TABLE users
   ADD darkmode BOOLEAN NOT NULL DEFAULT FALSE;
 
 -- migrate:down
-
+ALTER TABLE users
+  DROP darkmode;

--- a/db/migrations/20230719085253_alterUserTblAddThumbnail.sql
+++ b/db/migrations/20230719085253_alterUserTblAddThumbnail.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+ALTER TABLE users
+  ADD COLUMN profile_image_url VARCHAR(255) NULL;
+
+-- migrate:down
+ALTER TABLE users
+  DROP COLUMN profile_image_url;
+
+

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -163,6 +163,7 @@ CREATE TABLE `users` (
   `nickname` varchar(30) DEFAULT NULL,
   `email` varchar(50) DEFAULT NULL,
   `darkmode` tinyint(1) NOT NULL DEFAULT '0',
+  `profile_image_url` varchar(1000) DEFAULT NULL,
   PRIMARY KEY (`user_id`),
   UNIQUE KEY `nickname` (`nickname`),
   UNIQUE KEY `email` (`email`)
@@ -199,5 +200,6 @@ INSERT INTO `schema_migrations` (version) VALUES
   ('20230612082754'),
   ('20230612082810'),
   ('20230612082824'),
-  ('20230714065552');
+  ('20230714065552'),
+  ('20230719085253');
 UNLOCK TABLES;


### PR DESCRIPTION
# PR template

## ☘️ 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

---


## 🔑 Key Changes

- my page에 노출할 유저 정보 (닉네임, 이메일, 프로필 이미지, 다크모드)

- `users` 테이블에 `profile_image_url` 컬럼 VARCHAR(255)로 설정하여 추가
  - 초반 서비스 기획 중 my page 이외 유저의 이미지 정보 노출하는 페이지가 없음
  - 자체 서비스 회원가입에서 랜덤 이미지 제공 예정이기 때문에 이미지가 저장공간의 큰 부분을 차지할 필요가 없음
  - 업계에서 url 저장 시 보통 2083자로 설정하지만, 위 이유들로 url의 VARCHAR 길이를 255자로 설정하여 이를 초과하는 유저의 이미지를 랜덤이미지로 부여하여 서비스 제공할 예정
  
- dark 모드 설정 변경에 대한 API 생성

---

## 😎 To Reviewers

- 유저 이미지 url 길이에 따른 문의가 있으면 알려주세요.
- 현재, kakao에서 받는 데이터의 위계를 잘못 파악하여 Sign up의 코드를 재설정해야 할 필요성이 있음. 또한 profile 이미지 대신 사용할 랜덤 이미지를 어떤 방식으로 사용할지에 대해 결정이 필요함.

